### PR TITLE
Fix error: "Unknown token T" if passing a bool to a boolean option (and some cleanup)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,12 @@ etherpad_title: 'Etherpad'
 etherpad_mail_admin: 'root@{{ ansible_domain }}'
 
 # Text displayed on all new pads by default
-etherpad_welcome_text: 'Welcome to {{ etherpad_title }}!\n\nThis pad is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents.\n\nContact with administrator: mailto:{{ etherpad_mail_admin }}\n\n'
+etherpad_welcome_text: |
+  Welcome to {{ etherpad_title }}!
+
+  This pad is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents.
+
+  Contact with administrator: mailto:{{ etherpad_mail_admin }}
 
 
 # ---- Database and network ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,19 +54,19 @@ etherpad_admins: [ 'admin' ]
 etherpad_users: []
 
 # Require authentication from all users
-etherpad_require_authentication: 'false'
+etherpad_require_authentication: False
 
 # Require authorization by a module or user with is_admin = True
-etherpad_require_authorization: 'false'
+etherpad_require_authorization: False
 
 # Require session to access pads
-etherpad_require_session: 'false'
+etherpad_require_session: False
 
 # Block creation of new pads by unauthorized users?
-etherpad_edit_only: 'false'
+etherpad_edit_only: False
 
 # Trust the reverse proxy (nginx)?
-etherpad_trust_proxy: 'false'
+etherpad_trust_proxy: False
 
 
 # ---- Etherpad customization ----
@@ -98,13 +98,13 @@ etherpad_plugins:
 # ---- Other options ----
 
 # Minify CSS and JS assets?
-etherpad_minify: 'true'
+etherpad_minify: True
 
 # Maximum age of cached assets (6 hours by default)
 etherpad_max_age: '{{ (60 * 60 * 6) }}'
 
 # Disable IP addresses in logs?
-etherpad_disable_ip_logging: 'false'
+etherpad_disable_ip_logging: False
 
 # Etherpad log level (choices: DEBUG, INFO, WARN, ERROR)
 etherpad_loglevel: 'INFO'

--- a/templates/srv/users/etherpad/etherpad-lite/settings.json.j2
+++ b/templates/srv/users/etherpad/etherpad-lite/settings.json.j2
@@ -35,7 +35,7 @@
 
   // The Type of the database. You can choose between dirty, postgres, sqlite and mysql
   // You shouldn't use "dirty" for for anything else than testing or development
-{% if etherpad_database is defined and etherpad_database %}
+{% if etherpad_database %}
 {% if etherpad_database == 'dirty' %}
   "dbType" : "dirty",
   "dbSettings" : {
@@ -46,7 +46,7 @@
    "dbSettings" : {
                     "user"    : "{{ etherpad_database_config[etherpad_database].username }}",
                     "host"    : "{{ etherpad_database_config[etherpad_database].hostname }}",
-{% if etherpad_database_connection is defined and etherpad_database_connection %}
+{% if etherpad_database_connection %}
 {% if etherpad_database_connection == 'port' %}
                     "port"    : "{{ etherpad_database_config[etherpad_database].port }}",
 {% else %}
@@ -68,41 +68,41 @@
   "defaultPadText" : "{{ etherpad_welcome_text }}",
 
   // Users must have a session to access pads. This effectively allows only group pads to be accessed.
-  "requireSession" : {{ etherpad_require_session | default('false') }},
+  "requireSession" : {{ etherpad_require_session }},
 
   // Users may edit pads but not create new ones. Pad creation is only
   // via the API. This applies both to group pads and regular pads.
-  "editOnly" : {{ etherpad_edit_only | default('false') }},
+  "editOnly" : {{ etherpad_edit_only }},
 
   // If true, all css & js will be minified before sending to the
   // client. This will improve the loading performance massivly, but
   // makes it impossible to debug the javascript/css
-  "minify" : {{ etherpad_minify | default('true') }},
+  "minify" : {{ etherpad_minify }},
 
   // How long may clients use served javascript code (in seconds)? Without versioning this
   // may cause problems during deployment. Set to 0 to disable caching
-  "maxAge" : {{ etherpad_max_age | default('21600') }}, // 60 * 60 * 6 = 6 hours
+  "maxAge" : {{ etherpad_max_age }},
 
   // This is the path to the Abiword executable. Setting it to null, disables abiword.
   // Abiword is needed to advanced import/export features of pads
-  "abiword" : {% if etherpad_abiword is defined and etherpad_abiword %}"/usr/bin/abiword"{% else %}null{% endif %},
+  "abiword" : {% if etherpad_abiword %}"/usr/bin/abiword"{% else %}null{% endif %},
 
   // This setting is used if you require authentication of all users.
   // Note: /admin always requires authentication.
-  "requireAuthentication": {{ etherpad_require_authentication | default('false') }},
+  "requireAuthentication": {{ etherpad_require_authentication }},
 
   // Require authorization by a module, or a user with is_admin set, see below.
-  "requireAuthorization": {{ etherpad_require_authorization | default('false') }},
+  "requireAuthorization": {{ etherpad_require_authorization }},
 
   // When you use NginX or another proxy/ load-balancer set this to true
-  "trustProxy": {{ etherpad_trust_proxy | default('false') }},
+  "trustProxy": {{ etherpad_trust_proxy }},
 
   // Privacy: disable IP logging
-  "disableIPlogging": {{ etherpad_disable_ip_logging | default('false') }},
+  "disableIPlogging": {{ etherpad_disable_ip_logging }},
 
   // Users for basic authentication. is_admin = true gives access to /admin.
   // If you do not uncomment this, /admin will not be available!
-{% if (secret is defined and secret) and ((etherpad_admins is defined and etherpad_admins) or (etherpad_users is defined and etherpad_users)) %}
+{% if (secret is defined and secret) and (etherpad_admins or etherpad_users) %}
   "users": {
 {% for name in etherpad_admins %}
     "{{ name }}": {
@@ -144,7 +144,7 @@
   */
 
   // The log level we are using, can be: DEBUG, INFO, WARN, ERROR
-  "loglevel": "{{ etherpad_loglevel | default('INFO') }}",
+  "loglevel": "{{ etherpad_loglevel }}",
 
   // Logging configuration. See log4js documentation for further information
   // https://github.com/nomiddlename/log4js-node
@@ -189,7 +189,7 @@
         }
     */
       ]
-{% if etherpad_custom_json is defined and etherpad_custom_json %}
+{% if etherpad_custom_json %}
     },
     {{ (etherpad_custom_json | to_nice_json)[1:][:-1] | trim }}
 {% else %}

--- a/templates/srv/users/etherpad/etherpad-lite/settings.json.j2
+++ b/templates/srv/users/etherpad/etherpad-lite/settings.json.j2
@@ -1,8 +1,8 @@
-/*
-  This file is managed by Ansible, all changes will be lost
-
-  This file must be valid JSON. But comments are allowed
-*/
+//
+//  This file is managed by Ansible, all changes will be lost
+//
+//  This file must be valid JSON. But comments are allowed
+//
 {
   // Name your instance!
   "title": "{{ etherpad_title }}",
@@ -67,39 +67,41 @@
   //the default text of a pad
   "defaultPadText" : "{{ etherpad_welcome_text }}",
 
-  /* Users must have a session to access pads. This effectively allows only group pads to be accessed. */
+  // Users must have a session to access pads. This effectively allows only group pads to be accessed.
   "requireSession" : {{ etherpad_require_session | default('false') }},
 
-  /* Users may edit pads but not create new ones. Pad creation is only via the API. This applies both to group pads and regular pads. */
+  // Users may edit pads but not create new ones. Pad creation is only
+  // via the API. This applies both to group pads and regular pads.
   "editOnly" : {{ etherpad_edit_only | default('false') }},
 
-  /* if true, all css & js will be minified before sending to the client. This will improve the loading performance massivly,
-     but makes it impossible to debug the javascript/css */
+  // If true, all css & js will be minified before sending to the
+  // client. This will improve the loading performance massivly, but
+  // makes it impossible to debug the javascript/css
   "minify" : {{ etherpad_minify | default('true') }},
 
-  /* How long may clients use served javascript code (in seconds)? Without versioning this
-     may cause problems during deployment. Set to 0 to disable caching */
+  // How long may clients use served javascript code (in seconds)? Without versioning this
+  // may cause problems during deployment. Set to 0 to disable caching
   "maxAge" : {{ etherpad_max_age | default('21600') }}, // 60 * 60 * 6 = 6 hours
 
-  /* This is the path to the Abiword executable. Setting it to null, disables abiword.
-     Abiword is needed to advanced import/export features of pads*/
+  // This is the path to the Abiword executable. Setting it to null, disables abiword.
+  // Abiword is needed to advanced import/export features of pads
   "abiword" : {% if etherpad_abiword is defined and etherpad_abiword %}"/usr/bin/abiword"{% else %}null{% endif %},
 
-  /* This setting is used if you require authentication of all users.
-     Note: /admin always requires authentication. */
+  // This setting is used if you require authentication of all users.
+  // Note: /admin always requires authentication.
   "requireAuthentication": {{ etherpad_require_authentication | default('false') }},
 
-  /* Require authorization by a module, or a user with is_admin set, see below. */
+  // Require authorization by a module, or a user with is_admin set, see below.
   "requireAuthorization": {{ etherpad_require_authorization | default('false') }},
 
-  /*when you use NginX or another proxy/ load-balancer set this to true*/
+  // When you use NginX or another proxy/ load-balancer set this to true
   "trustProxy": {{ etherpad_trust_proxy | default('false') }},
 
-  /* Privacy: disable IP logging */
+  // Privacy: disable IP logging
   "disableIPlogging": {{ etherpad_disable_ip_logging | default('false') }},
 
-  /* Users for basic authentication. is_admin = true gives access to /admin.
-     If you do not uncomment this, /admin will not be available! */
+  // Users for basic authentication. is_admin = true gives access to /admin.
+  // If you do not uncomment this, /admin will not be available!
 {% if (secret is defined and secret) and ((etherpad_admins is defined and etherpad_admins) or (etherpad_users is defined and etherpad_users)) %}
   "users": {
 {% for name in etherpad_admins %}
@@ -121,7 +123,8 @@
   // restrict socket.io transport methods
   "socketTransportProtocols" : ["xhr-polling", "jsonp-polling", "htmlfile"],
 
-  /* The toolbar buttons configuration.
+  /*
+  // The toolbar buttons configuration.
   "toolbar": {
     "left": [
       ["bold", "italic", "underline", "strikethrough"],
@@ -140,10 +143,10 @@
   },
   */
 
-  /* The log level we are using, can be: DEBUG, INFO, WARN, ERROR */
+  // The log level we are using, can be: DEBUG, INFO, WARN, ERROR
   "loglevel": "{{ etherpad_loglevel | default('INFO') }}",
 
-  //Logging configuration. See log4js documentation for further information
+  // Logging configuration. See log4js documentation for further information
   // https://github.com/nomiddlename/log4js-node
   // You can add as many appenders as you want here:
   "logconfig" :
@@ -157,13 +160,15 @@
       , "maxLogSize": 1024
       , "backups": 3 // how many log files there're gonna be at max
       //, "category": "test" // only log a specific category
-        }*/
+        }
+    */
     /*
       , { "type": "logLevelFilter"
         , "level": "warn" // filters out all log messages that have a lower level than "error"
         , "appender":
           {  Use whatever appender you want here  }
-        }*/
+        }
+    */
     /*
       , { "type": "logLevelFilter"
         , "level": "error" // filters out all log messages that have a lower level than "error"
@@ -181,7 +186,8 @@
               }
             }
           }
-        }*/
+        }
+    */
       ]
 {% if etherpad_custom_json is defined and etherpad_custom_json %}
     },

--- a/templates/srv/users/etherpad/etherpad-lite/settings.json.j2
+++ b/templates/srv/users/etherpad/etherpad-lite/settings.json.j2
@@ -68,16 +68,16 @@
   "defaultPadText" : "{{ etherpad_welcome_text }}",
 
   // Users must have a session to access pads. This effectively allows only group pads to be accessed.
-  "requireSession" : {{ etherpad_require_session }},
+  "requireSession" : {{ etherpad_require_session | lower }},
 
   // Users may edit pads but not create new ones. Pad creation is only
   // via the API. This applies both to group pads and regular pads.
-  "editOnly" : {{ etherpad_edit_only }},
+  "editOnly" : {{ etherpad_edit_only | lower }},
 
   // If true, all css & js will be minified before sending to the
   // client. This will improve the loading performance massivly, but
   // makes it impossible to debug the javascript/css
-  "minify" : {{ etherpad_minify }},
+  "minify" : {{ etherpad_minify | lower }},
 
   // How long may clients use served javascript code (in seconds)? Without versioning this
   // may cause problems during deployment. Set to 0 to disable caching
@@ -89,16 +89,16 @@
 
   // This setting is used if you require authentication of all users.
   // Note: /admin always requires authentication.
-  "requireAuthentication": {{ etherpad_require_authentication }},
+  "requireAuthentication": {{ etherpad_require_authentication | lower }},
 
   // Require authorization by a module, or a user with is_admin set, see below.
-  "requireAuthorization": {{ etherpad_require_authorization }},
+  "requireAuthorization": {{ etherpad_require_authorization | lower }},
 
   // When you use NginX or another proxy/ load-balancer set this to true
-  "trustProxy": {{ etherpad_trust_proxy }},
+  "trustProxy": {{ etherpad_trust_proxy | lower }},
 
   // Privacy: disable IP logging
-  "disableIPlogging": {{ etherpad_disable_ip_logging }},
+  "disableIPlogging": {{ etherpad_disable_ip_logging | lower }},
 
   // Users for basic authentication. is_admin = true gives access to /admin.
   // If you do not uncomment this, /admin will not be available!


### PR DESCRIPTION
I was cough by this: When setting e.g. "etherpad_edit_only: True" (as it is common in YAML), this resulted in wrong json where "true" has to be lower case. Avoid this by converting to lower case.

I've checked that this works as expected for existing string-values using this playbook:
```
---
- hosts: all
  gather_facts: False

  vars:
    x1: True
    x2: 'true'
    x3: False
    x4: 'False'
    x5: []          # a list!

  tasks:
  - debug: msg='should be  true {{x1 | lower}}'
  - debug: msg='should be  true {{x2 | lower}}'
  - debug: msg='should be false {{x3 | lower}}'
  - debug: msg='should be false {{x4 | lower}}'
  - debug: msg='should be    [] {{x5 | lower}}'  # converted to lower string, too :-)
```
