### PR TITLE
Allow playbook to specify listen port(s) for nginx server.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,6 +55,7 @@ etherpad_nginx_server:
   default: False
   favicon: False
   name: '{{ etherpad_domain }}'
+  listen: "{{ etherpad_listen_port if (etherpad_listen_port|d()) else ['[::]:80'] }}"
 
   location:
 


### PR DESCRIPTION
It turned out to be useful to me to be able to allow a playbook or host_var to specify the listen port(s).

Lemme know if it looks ok?
