### PR TITLE
Fix creation of log directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,7 +87,7 @@
   notify: [ 'Assemble services.d' ]
 
 - name: Create log directory
-  file: state=directory path=/var/log/{{ etherpad_user }}
+  file: state=directory path=/var/log/etherpad-lite
         owner={{ etherpad_user }} group=adm mode=0755
 
 - name: Configure etherpad-lite system service


### PR DESCRIPTION
This must be same same as in /etc/init.d/etherpad-lite